### PR TITLE
Added support for macOS and Apple Silicon through MoltenVK portability layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ cmake_build_linux/
 _install/
 .vscode/
 _autogen/
+# clangd
+.cache/ 

--- a/cmake/FindSlang.cmake
+++ b/cmake/FindSlang.cmake
@@ -12,7 +12,7 @@
 #
 # Creates an imported library, `Slang`, that can be linked against.
 
-set(Slang_VERSION "2025.13.1")
+set(Slang_VERSION "2026.1")
 
 string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" ARCH_PROC)
 if(ARCH_PROC MATCHES "^(arm|aarch64)")
@@ -35,6 +35,8 @@ endif()
 
 if(WIN32)
     set(SLANG_OS "windows")
+elseif(APPLE)
+    set(SLANG_OS "macos")
 else()
     set(SLANG_OS "linux")
 endif()

--- a/src/minimal_latest.cpp
+++ b/src/minimal_latest.cpp
@@ -103,7 +103,7 @@ this regular expression:
 #endif
 #include "volk.h"
 #ifdef __APPLE__
-#include <vulkan/vulkan_beta.h>
+#include <vulkan/vulkan_beta.h> // More macOS portability things
 #endif
 /*--
  * We are using the Vulkan Memory Allocator (VMA) to manage memory.

--- a/src/minimal_latest.cpp
+++ b/src/minimal_latest.cpp
@@ -834,7 +834,9 @@ private:
         .ppEnabledExtensionNames = instanceExtensions.data(),
     };
 
+    #ifdef __APPLE__
     instanceCreateInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+    #endif
 
     // Actual Vulkan instance creation
     VK_CHECK(vkCreateInstance(&instanceCreateInfo, nullptr, &m_instance));
@@ -949,8 +951,9 @@ private:
     pNextChainPushFront(&m_features11, &m_features12);
     pNextChainPushFront(&m_features11, &m_features13);
     pNextChainPushFront(&m_features11, &m_features14);
+    #ifdef __APPLE__
     pNextChainPushFront(&m_features11, &m_portabilityFeatures);  // MoltenVK portability subset
-
+    #endif
     /*-- 
      * Process device extensions from configuration:
      * - Check if each extension is available on the device


### PR DESCRIPTION
Added supports for macOS and Apple Silicon through MoltenVK portability layer. Tested only on MacBook Pro M1 Pro.

- Slang is now fetched for macOS properly
- Uses Vulkan Portability extension to create instance and device
- MoltenVK does not support "component swizzle", so we need to ignore it for macOS. Apparently still works. Disclaimer: I've used Claude to fixe this error since I did not understand how to check for a portability feature availability.
- Most macOS specific code is under #ifdef because it's not guaranteed Windows and Linux SDKs offer the portability layer, so it would not even compile I guess.

There are still some validation errors, but still, it surprisingly works:

<img width="1404" height="633" alt="image" src="https://github.com/user-attachments/assets/8ac564b4-f6d5-4e0e-abfb-0122bed1b19d" />

<img width="797" height="633" alt="image" src="https://github.com/user-attachments/assets/1a517085-b021-449e-89d5-456d388bd3e0" />