### PR TITLE
Find and configure Vulkan-Utility-Libraries target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include(FetchContent)
 
 # Find Vulkan
 find_package(Vulkan REQUIRED)
+find_package(VulkanUtilityLibraries REQUIRED)
 
 # Add cmake modules directory to module path
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -145,6 +146,7 @@ target_link_libraries(${MYPROJ} PRIVATE
   volk
   imgui
   glm
+  Vulkan::UtilityHeaders
 )
 
 # Link system libraries on Linux


### PR DESCRIPTION
This PR modifies the CMake build to find and configure [Vulkan-Utility-Libraries](https://github.com/KhronosGroup/Vulkan-Utility-Libraries) for linking the target.

This fixes a build error on systems that do not use the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home) but may have a separate package for [vulkan-utility-libraries](https://archlinux.org/packages/extra/x86_64/vulkan-utility-libraries/).

```
$ cmake --build build --config Release
[9/11] Building CXX object CMakeFiles/vk_minimal_latest.dir/src/minimal_latest.cpp.o
FAILED: [code=1] CMakeFiles/vk_minimal_latest.dir/src/minimal_latest.cpp.o 
/usr/bin/clang++ -DIMGUI_IMPL_VULKAN_USE_VOLK -DUSE_SLANG -DVK_NO_PROTOTYPES -I/home/silvanshade/Development/vk_minimal_latest/build/_deps/vulkanmemoryallocator-src/include -I/home/silvanshade/Development/vk_minimal_latest/build -I/home/silvanshade/Development/vk_minimal_latest -I/home/silvanshade/Development/vk_minimal_latest/build/_deps/glfw-src/include -I/home/silvanshade/Development/vk_minimal_latest/build/_deps/volk-src -I/home/silvanshade/Development/vk_minimal_latest/build/_deps/imgui-src -I/home/silvanshade/Development/vk_minimal_latest/build/_deps/glm-src -g -std=gnu++20 -MD -MT CMakeFiles/vk_minimal_latest.dir/src/minimal_latest.cpp.o -MF CMakeFiles/vk_minimal_latest.dir/src/minimal_latest.cpp.o.d -o CMakeFiles/vk_minimal_latest.dir/src/minimal_latest.cpp.o -c /home/silvanshade/Development/vk_minimal_latest/src/minimal_latest.cpp
/home/silvanshade/Development/vk_minimal_latest/src/minimal_latest.cpp:136:10: fatal error: 'vulkan/vk_enum_string_helper.h' file not found
  136 | #include "vulkan/vk_enum_string_helper.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
ninja: build stopped: subcommand failed.
```
